### PR TITLE
feat: implement visualization module in 2.0 (#68)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ t3co/resources/T3CO_Config_Local.csv
 /tco_results
 /src/t3co/resources/auxiliary/payload_pdf.csv
 /src/results
+/results
 /src/t3co/resources/results
 !/src/t3co/resources/cost_toggles.json

--- a/docs/pages/cost_and_tool_features.md
+++ b/docs/pages/cost_and_tool_features.md
@@ -46,7 +46,7 @@ When a US zipcode is provided in the Config or Scenario `region` field, T3CO can
 - Dynamic Wireless Power Transfer - Analyze on-road charging technologies and its impact on cost
 - Optimization Toolbox with NSGA2, PatternSearch, NelderMead, and PSO algorithms for vehicle sizing and TCO minimization
 - Regionalized fuel prices via EIA AEO API with automatic zipcode-to-census-division resolution
-- Charts Module to visualize Ledgers and large sets of T3CO results
+- Visualization module to plot TCO breakdowns, histograms, and violin plots from results — static (matplotlib) or interactive HTML (Plotly), with a `--plot` flag on the sweep CLI
 
 ## Features Roadmap
 

--- a/docs/pages/visualization.md
+++ b/docs/pages/visualization.md
@@ -55,9 +55,18 @@ Distribution of a metric across categories (e.g. `mpgge` by fuel type).
 
 <img src="../images/violinplot_sample.png" alt="Violin plot" width="400"/>
 
+## Interactive explorer
+
+`generate_interactive_plot()` returns a Plotly scatter with **dropdown menus to choose the x- and y-axis columns** directly on the page — pick any grouping column or numeric output for either axis and the chart updates client-side, no server needed. It always renders with Plotly (interactive only) and leads the combined HTML report.
+
+```python
+tc = T3COCharts(filename="results.csv", backend="plotly")
+tc.generate_interactive_plot(default_x="vehicle_fuel_type", default_y="discounted_tco_dol")
+```
+
 ## Charts from the CLI
 
-Add `--plot` to a sweep run to generate the default charts next to the results CSV. The Plotly backend combines them into a **single self-contained HTML report** (`<results>_charts.html`); matplotlib writes one PNG per chart:
+Add `--plot` to a sweep run to generate the default charts next to the results CSV. The Plotly backend combines the interactive explorer plus the three standard charts into a **single self-contained HTML report** (`<results>_charts.html`); matplotlib writes one PNG per chart:
 
 ```bash
 python -m t3co.cli.sweep --analysis-id=0 --plot             # one combined HTML (Plotly, default)

--- a/docs/pages/visualization.md
+++ b/docs/pages/visualization.md
@@ -1,0 +1,57 @@
+# Visualization
+
+The [`T3COCharts`](./api/charts.md) class (`t3co.visualize.charts`) turns a T3CO results CSV (or DataFrame) into three plots, each rendered with a selectable backend:
+
+- `backend="matplotlib"` (default) — static figures for PNG/PDF export.
+- `backend="plotly"` — interactive, self-contained HTML.
+
+## Install
+
+The plotting libraries are an optional extra:
+
+```bash
+pip install t3co[viz]
+```
+
+`matplotlib` is already a core T3CO dependency, so the TCO breakdown and histogram render without the extra. The violin plot additionally needs `seaborn`, and the interactive HTML backend needs `plotly`.
+
+## Usage
+
+```python
+from t3co.visualize.charts import T3COCharts
+
+tc = T3COCharts(filename="results.csv", backend="plotly")
+fig = tc.generate_tco_plots(x_group_col="vehicle_fuel_type", subplot_group_col="vehicle_type")
+fig.write_html("tco_breakdown.html")   # or fig.savefig(...) with the matplotlib backend
+```
+
+`T3COCharts` reads the prefixed result columns directly and derives the grouping columns (`vehicle_fuel_type`, `vehicle_type`, `vehicle_weight_class`, `veh_pt_type`) automatically. Each `generate_*` method returns a figure object that you save or display yourself.
+
+### TCO Breakdown
+
+Stacked cost components per scenario, with a marker for the discounted TCO. Pass `x_group_col` and/or `y_group_col` to split the results into a subplot grid (e.g. by fuel type and weight class).
+
+<img src="../images/tco_breakdown_sample.png" alt="TCO breakdown" width="650"/>
+
+### Histogram
+
+Distribution of any numeric output across selections. `show_pct=True` plots the percentage of scenarios instead of a count.
+
+<img src="../images/histogram_sample.png" alt="Histogram" width="400"/>
+
+### Violin
+
+Distribution of a metric across categories (e.g. `mpgge` by fuel type).
+
+<img src="../images/violinplot_sample.png" alt="Violin plot" width="400"/>
+
+## Charts from the CLI
+
+Add `--plot` to a sweep run to generate the three charts and save them next to the results CSV:
+
+```bash
+python -m t3co.cli.sweep --analysis-id=0 --plot             # interactive HTML (Plotly, default)
+python -m t3co.cli.sweep --analysis-id=0 --plot matplotlib  # static PNG
+```
+
+The [`visualization_demo.py`](https://github.com/NatLabRockies/T3CO/tree/main/src/t3co/demos/visualization_demo.py) script shows the full programmatic workflow in both backends.

--- a/docs/pages/visualization.md
+++ b/docs/pages/visualization.md
@@ -23,6 +23,16 @@ from t3co.visualize.charts import T3COCharts
 tc = T3COCharts(filename="results.csv", backend="plotly")
 fig = tc.generate_tco_plots(x_group_col="vehicle_fuel_type", subplot_group_col="vehicle_type")
 fig.write_html("tco_breakdown.html")   # or fig.savefig(...) with the matplotlib backend
+
+# Combine several Plotly figures into one self-contained HTML report:
+T3COCharts.write_html_report(
+    [
+        tc.generate_tco_plots(x_group_col="vehicle_fuel_type"),
+        tc.generate_histogram(hist_col="discounted_tco_dol", n_bins=10),
+        tc.generate_violin_plot(x_group_col="vehicle_fuel_type", y_group_col="mpgge"),
+    ],
+    "charts.html",
+)
 ```
 
 `T3COCharts` reads the prefixed result columns directly and derives the grouping columns (`vehicle_fuel_type`, `vehicle_type`, `vehicle_weight_class`, `veh_pt_type`) automatically. Each `generate_*` method returns a figure object that you save or display yourself.
@@ -47,11 +57,11 @@ Distribution of a metric across categories (e.g. `mpgge` by fuel type).
 
 ## Charts from the CLI
 
-Add `--plot` to a sweep run to generate the three charts and save them next to the results CSV:
+Add `--plot` to a sweep run to generate the default charts next to the results CSV. The Plotly backend combines them into a **single self-contained HTML report** (`<results>_charts.html`); matplotlib writes one PNG per chart:
 
 ```bash
-python -m t3co.cli.sweep --analysis-id=0 --plot             # interactive HTML (Plotly, default)
-python -m t3co.cli.sweep --analysis-id=0 --plot matplotlib  # static PNG
+python -m t3co.cli.sweep --analysis-id=0 --plot             # one combined HTML (Plotly, default)
+python -m t3co.cli.sweep --analysis-id=0 --plot matplotlib  # separate PNGs
 ```
 
 The [`visualization_demo.py`](https://github.com/NatLabRockies/T3CO/tree/main/src/t3co/demos/visualization_demo.py) script shows the full programmatic workflow in both backends.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -53,63 +53,25 @@ When a folder path is provided in the T3COConfig.csv file (`config.drive_cycle`)
 T3CO presents a demo file (`src/t3co/demos/demo.py`) for generating a `TCOCalc` for a specific year and a `Ledger` object for a given vehicle, scenario, and energy inputs. It showcases the modularity of the tool and allows the user to also download the results as a JSON or CSV file.
 
 ## Other Command Line Interface arguments
-Use the command below to get a list of all CLI arguments:
-```bash
-python -m t3co.cli.sweep --help
-```
+
+Run `python -m t3co.cli.sweep --help` for the full list of CLI arguments. Common ones:
+
+- `--plot [plotly|matplotlib]` — generate TCO charts after the run (see [Visualization](./pages/visualization.md)).
+- `--run-multi` / `--n-processors N` — Batch Mode multiprocessing (see above).
+- `--eia-api-key`, `--eia-aeo-year`, `--eia-aeo-case` — control EIA fuel price lookups.
 
 ### EIA Fuel Price Projections
 
-T3CO can fetch fuel price projections directly from the EIA Annual Energy Outlook (AEO) API. This replaces the static `FuelPrices.csv` data with the latest AEO projections for a region matching the provided US zipcode.
-
-**Setup:**
-1. Get a free EIA API key from [eia.gov/opendata/register.php](https://www.eia.gov/opendata/register.php)
-2. Add it to a `.env` file in your project root:
-   ```
-   T3CO_EIA_API_KEY=your_api_key_here
-   ```
-
-**Usage:** Set the `region` column in `T3COConfig.csv` to a 5-digit US zipcode. T3CO will auto-discover the latest AEO year, resolve the zipcode to a US Census division, and fetch fuel prices for that region.
-
-```bash
-python -m t3co.cli.sweep --analysis-id=5
-```
-
-The same zipcode-based resolution also works at the Scenario level — if a scenario's `region` field contains a zipcode and the config didn't already resolve one, T3CO fetches EIA data for that scenario.
-
-To override the AEO year or scenario (instead of using the latest):
-```bash
-python -m t3co.cli.sweep --analysis-id=5 --eia-aeo-year=2023 --eia-aeo-case=aeo2022ref
-```
-
-The `eia_fuel_prices` toggle in `cost_toggles.json` controls whether EIA lookups are enabled (default: `true`). If the toggle is `false` or no zipcode is provided, T3CO falls back to the static `FuelPrices.csv`.
+Instead of the static `FuelPrices.csv`, T3CO can fetch regional projections from the EIA Annual Energy Outlook (AEO) API. Set `region` to a 5-digit US zipcode in `T3COConfig.csv`, add a free [EIA API key](https://www.eia.gov/opendata/register.php) to a `.env` file (`T3CO_EIA_API_KEY=...`), and run as usual (e.g. `--analysis-id=5`). See [What's New in 2.0](./whats_new.md#eia-fuel-price-projections) for the full behavior, fallbacks, and AEO year/case overrides.
 
 ### Fuel Price Overrides
 
-For fuel-price sensitivity work, `--fuel-prices-json` accepts a JSON string or file path with `zipcode` and `fuel_prices` keys. T3CO uses the installed `zipcodes` package to resolve that ZIP code into the base fuel-price region before cloning and overriding the matching rows in `FuelPrices.csv`.
+For fuel-price sensitivity work, `--fuel-prices-json` takes a JSON string or file path with `zipcode` and `fuel_prices` keys; T3CO resolves the zipcode to a fuel-price region and overrides the matching `FuelPrices.csv` rows:
 
 ```bash
 python -m t3co.cli.sweep \
   --analysis-id=0 \
   --fuel-prices-json='{"zipcode":"80302","fuel_prices":{"diesel_dol_per_gal":{"2025":4.25}}}'
-```
-
-Selected CLI arguments related to EIA fuel price data fetching:
-
-```
-  --eia-api-key EIA_API_KEY
-                        EIA API key (prefer setting T3CO_EIA_API_KEY in .env file instead).
-  --eia-aeo-year EIA_AEO_YEAR
-                        AEO publication year to query (e.g. '2023', '2025').
-                        Default: auto-discover latest.
-  --eia-aeo-case EIA_AEO_CASE
-                        AEO scenario case ID (e.g. 'aeo2023ref').
-                        Default: auto-discover reference case.
-```
-
-For the full list of CLI arguments, run:
-```bash
-python -m t3co.cli.sweep --help
 ```
 
 ## T3CO Results
@@ -118,20 +80,11 @@ After running the analysis, T3CO stores the results .CSV file in the directory s
 The results file includes a comprehensive list of [***Ledger Outputs***](./pages/ledger_outputs_descriptions.md) that were calculated by the various ***T3CO Modules***. In addition to the T3CO outputs, all the *Vehicle* input parameters (denoted by a prefix: `input_vehicle_value_`), *Scenario* input parameters(denoted by a prefix: `scenario_`), and *Config* parameters (denoted by a prefix: `config_`) are also present in the results file. When the optional optimization module is run, the optimized vehicle parameters are also listed ((denoted by a prefix: `optimized_vehicle_value_`)) instead of NaN values for non-optimization runs.
 
 ## T3CO Visualization
-T3CO provides a demo file ([`t3co.demos.demo`](https://github.com/NatLabRockies/T3CO/tree/main/src/t3co/demos/demo.py)) for generating a `TCOCalc` for a specific year and a `Ledger` object for a given vehicle, scenario, and energy inputs. It showcases the modularity of the tool and allows the user to also download the results as a JSON or CSV file. The following visualization plots can be generated from T3CO results:
 
-- TCO Breakdown Chart
+Turn a results CSV into a TCO breakdown chart, histogram, or violin plot — as static images (matplotlib) or interactive HTML (Plotly). Generate them automatically after a run with `--plot`:
 
-<img src="https://raw.githubusercontent.com/NatLabRockies/T3CO/refs/heads/main/docs/images/tco_breakdown_sample.png" alt="tcobreakdown" width="650"/>
+```bash
+python -m t3co.cli.sweep --analysis-id=0 --plot
+```
 
-
-- Histogram Plot
-
-<img src="https://raw.githubusercontent.com/NatLabRockies/T3CO/refs/heads/main/docs/images/histogram_sample.png" alt="histogram" width="400"/>
-
-- Violin Plot
-
-<img src="https://raw.githubusercontent.com/NatLabRockies/T3CO/refs/heads/main/docs/images/violinplot_sample.png" alt="violinplot" width="400"/>
-
-
-The user can provide other input parameters specific to each visualization method to further customize the plots.
+See the [Visualization](./pages/visualization.md) page for the `T3COCharts` API, backends, and examples.

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1,6 +1,6 @@
 # What's New in T3CO 2.0
 
-T3CO 2.0 is a major release that introduces live fuel price data fetching from the EIA API, an expanded optimization toolbox, a dataclass-driven configuration system, and broader Python version support.
+T3CO 2.0 is a major release that introduces live fuel price data fetching from the EIA API, an expanded optimization toolbox, a dataclass-driven configuration system, a new visualization module, and broader Python version support.
 
 ## EIA Fuel Price Projections
 
@@ -97,6 +97,15 @@ A new `t3co.data_fetching` module houses the `EIAClient` class, which provides:
 - **Retry logic** with exponential backoff for transient network errors.
 - **Caching** to avoid redundant API calls within a session.
 - **Data extrapolation** to fill gaps in the AEO time series using backfill and compound annual growth rates.
+
+## Visualization Module
+
+The `t3co.visualize.charts.T3COCharts` class generates TCO breakdown, histogram, and violin plots from a results CSV or DataFrame, with a selectable backend:
+
+- `matplotlib` (default) — static PNG/PDF figures.
+- `plotly` — interactive, self-contained HTML.
+
+Plotting libraries ship as an optional extra (`pip install t3co[viz]`), and a sweep run can emit the charts automatically with `--plot`. See the [Visualization](./pages/visualization.md) page.
 
 ## Migration from 1.x
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,7 +79,8 @@ nav:
       - Config: pages/config_inputs_descriptions.md
     - Outputs:
       - Ledger: pages/ledger_outputs_descriptions.md
-    - API Reference: 
+    - Visualization: pages/visualization.md
+    - API Reference:
       - Input Data Module:
         - Vehicle: pages/api/vehicle.md
         - Scenario: pages/api/scenario.md
@@ -96,6 +97,8 @@ nav:
         - Ledger: pages/api/ledger.md
       - CLI Module:
         - Sweep: pages/api/sweep.md
+      - Visualization Module:
+        - Charts: pages/api/charts.md
       - Utility Module:
         - Demo Files Installer: pages/api/demo_files_installer.md
         - Print Class Objects: pages/api/print_class_objects.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,14 @@ scipy = [
 ]
 pymoo = ">=0.6.0,<0.7"
 fastsim = { version = ">=2.1.1,<3", python = ">=3.9,<3.11", optional = true }
+matplotlib = { version = ">=3.7", optional = true }
+seaborn = { version = ">=0.13", optional = true }
+plotly = { version = ">=5.0", optional = true }
 
 [project.optional-dependencies]
 fastsim = ["fastsim>=2.1.1,<3; python_version < '3.11'"]
-dev = ["pytest", "pytest-mock", "fastsim>=2.1.1,<3; python_version < '3.11'", "ruff"]
+viz = ["matplotlib>=3.7", "seaborn>=0.13", "plotly>=5.0"]
+dev = ["pytest", "pytest-mock", "fastsim>=2.1.1,<3; python_version < '3.11'", "ruff", "matplotlib>=3.7", "seaborn>=0.13", "plotly>=5.0"]
 
 [project.scripts]
 install_t3co_demo_inputs = "t3co.utils.demo_inputs_installer:main"

--- a/src/t3co/cli/sweep.py
+++ b/src/t3co/cli/sweep.py
@@ -558,14 +558,16 @@ def save_default_plots(
     group_col = "vehicle_fuel_type" if "vehicle_fuel_type" in tc.group_columns else "None"
     subplot_col = "vehicle_type" if "vehicle_type" in columns else "scenario_name"
 
-    figure_specs = {
-        "tco_breakdown": lambda: tc.generate_tco_plots(
-            x_group_col=group_col, subplot_group_col=subplot_col
-        ),
-        "tco_histogram": lambda: tc.generate_histogram(
-            hist_col="discounted_tco_dol", n_bins=10
-        ),
-    }
+    figure_specs = {}
+    if tc.backend == "plotly":
+        # Interactive x/y column explorer, shown first in the HTML report.
+        figure_specs["explorer"] = lambda: tc.generate_interactive_plot()
+    figure_specs["tco_breakdown"] = lambda: tc.generate_tco_plots(
+        x_group_col=group_col, subplot_group_col=subplot_col
+    )
+    figure_specs["tco_histogram"] = lambda: tc.generate_histogram(
+        hist_col="discounted_tco_dol", n_bins=10
+    )
     if group_col != "None":
         figure_specs["tco_violin"] = lambda: tc.generate_violin_plot(
             x_group_col=group_col, y_group_col="discounted_tco_dol"

--- a/src/t3co/cli/sweep.py
+++ b/src/t3co/cli/sweep.py
@@ -513,13 +513,91 @@ def export_results_to_csv(
     )
 
 
-def run_t3co(config: Config, save_results: bool = True) -> None:
+DEFAULT_PLOT_BACKEND = "plotly"
+
+
+def save_default_plots(
+    results_csv: Union[str, Path],
+    backend: str = DEFAULT_PLOT_BACKEND,
+) -> List[Path]:
+    """
+    Generates and saves a default set of TCO charts from a results CSV.
+
+    Writes figures next to the results file: a TCO cost breakdown, a histogram of
+    the discounted TCO, and - when a fuel-type grouping is available - a violin
+    plot. Interactive Plotly charts are saved as HTML; matplotlib charts as PNG.
+
+    The plotting dependencies are optional; if they are missing (or charting
+    fails) the run is unaffected and a note is printed.
+
+    Args:
+        results_csv (Union[str, Path]): Path to the T3CO results CSV.
+        backend (str): "plotly" (interactive HTML) or "matplotlib" (static PNG).
+
+    Returns:
+        List[Path]: Paths of the saved figure files (empty if plotting was skipped).
+    """
+    try:
+        from t3co.visualize.charts import T3COCharts
+    except ImportError as e:
+        print(f"Skipping --plot: {e}")
+        return []
+
+    results_csv = Path(results_csv)
+    try:
+        tc = T3COCharts(filename=results_csv, backend=backend)
+    except Exception as e:
+        print(f"Skipping --plot: could not initialize charts ({type(e).__name__}: {e})")
+        return []
+
+    ext = "html" if tc.backend == "plotly" else "png"
+    out_dir = results_csv.parent
+    stem = results_csv.stem
+    columns = tc.to_df().columns
+
+    group_col = "vehicle_fuel_type" if "vehicle_fuel_type" in tc.group_columns else "None"
+    subplot_col = "vehicle_type" if "vehicle_type" in columns else "scenario_name"
+
+    figures = {
+        "tco_breakdown": lambda: tc.generate_tco_plots(
+            x_group_col=group_col, subplot_group_col=subplot_col
+        ),
+        "tco_histogram": lambda: tc.generate_histogram(
+            hist_col="discounted_tco_dol", n_bins=10
+        ),
+    }
+    if group_col != "None":
+        figures["tco_violin"] = lambda: tc.generate_violin_plot(
+            x_group_col=group_col, y_group_col="discounted_tco_dol"
+        )
+
+    saved = []
+    for name, make_fig in figures.items():
+        try:
+            fig = make_fig()
+            out = out_dir / f"{stem}_{name}.{ext}"
+            if tc.backend == "plotly":
+                fig.write_html(out)
+            else:
+                fig.savefig(out, bbox_inches="tight", dpi=120)
+            saved.append(out)
+            print(f"Saved plot: {out}")
+        except Exception as e:
+            print(f"  could not generate '{name}' plot ({type(e).__name__}: {e})")
+    return saved
+
+
+def run_t3co(
+    config: Config, save_results: bool = True, plot_backend: str = None
+) -> None:
     """
     Runs the T3CO analysis.
 
     Args:
         config (Config): The configuration instance.
         save_results (bool, optional): Whether to save the results. Defaults to True.
+        plot_backend (str, optional): If set ("plotly" or "matplotlib"), generates and
+            saves default TCO charts next to the results CSV. Defaults to None.
     """
     reports_list = []
     error_list = []
@@ -541,6 +619,8 @@ def run_t3co(config: Config, save_results: bool = True) -> None:
         if len(error_list):
             print(f"Selections {error_list} were skipped due to assumptions errors.")
         print(f"T3CO results saved to: {output_path}")
+        if plot_backend and output_path:
+            save_default_plots(output_path, backend=plot_backend)
 
 
 if __name__ == "__main__":
@@ -780,6 +860,16 @@ if __name__ == "__main__":
         type=str,
         help="AEO scenario case ID (e.g. 'aeo2023ref'). Default: auto-discover reference case.",
     )
+    parser.add_argument(
+        "--plot",
+        nargs="?",
+        const=DEFAULT_PLOT_BACKEND,
+        default=None,
+        choices=["plotly", "matplotlib", "seaborn"],
+        help="Generate TCO charts from the results after the run, saved next to the results CSV. "
+        "Use '--plot' for interactive Plotly HTML (default) or '--plot matplotlib' for static PNGs. "
+        "Requires the 'viz' extra: pip install t3co_go[viz].",
+    )
 
     args = parser.parse_args()
 
@@ -869,7 +959,10 @@ if __name__ == "__main__":
             sort_csv_file(input_path=result_filepath, sort_by="selection")
             print(f"T3CO results saved and sorted to: {result_filepath}")
 
+        if args.plot:
+            save_default_plots(result_filepath, backend=args.plot)
+
     else:
-        run_t3co(config=config, save_results=True)
+        run_t3co(config=config, save_results=True, plot_backend=args.plot)
 
     print(f"T3CO Run time: {time.time() - start}")

--- a/src/t3co/cli/sweep.py
+++ b/src/t3co/cli/sweep.py
@@ -525,7 +525,8 @@ def save_default_plots(
 
     Writes figures next to the results file: a TCO cost breakdown, a histogram of
     the discounted TCO, and - when a fuel-type grouping is available - a violin
-    plot. Interactive Plotly charts are saved as HTML; matplotlib charts as PNG.
+    plot. With the Plotly backend all charts are combined into a single
+    self-contained HTML report; with matplotlib each chart is a separate PNG.
 
     The plotting dependencies are optional; if they are missing (or charting
     fails) the run is unaffected and a note is printed.
@@ -550,7 +551,6 @@ def save_default_plots(
         print(f"Skipping --plot: could not initialize charts ({type(e).__name__}: {e})")
         return []
 
-    ext = "html" if tc.backend == "plotly" else "png"
     out_dir = results_csv.parent
     stem = results_csv.stem
     columns = tc.to_df().columns
@@ -558,7 +558,7 @@ def save_default_plots(
     group_col = "vehicle_fuel_type" if "vehicle_fuel_type" in tc.group_columns else "None"
     subplot_col = "vehicle_type" if "vehicle_type" in columns else "scenario_name"
 
-    figures = {
+    figure_specs = {
         "tco_breakdown": lambda: tc.generate_tco_plots(
             x_group_col=group_col, subplot_group_col=subplot_col
         ),
@@ -567,23 +567,33 @@ def save_default_plots(
         ),
     }
     if group_col != "None":
-        figures["tco_violin"] = lambda: tc.generate_violin_plot(
+        figure_specs["tco_violin"] = lambda: tc.generate_violin_plot(
             x_group_col=group_col, y_group_col="discounted_tco_dol"
         )
 
-    saved = []
-    for name, make_fig in figures.items():
+    # Generate the figures, skipping any individual chart that fails.
+    figures = {}
+    for name, make_fig in figure_specs.items():
         try:
-            fig = make_fig()
-            out = out_dir / f"{stem}_{name}.{ext}"
-            if tc.backend == "plotly":
-                fig.write_html(out)
-            else:
-                fig.savefig(out, bbox_inches="tight", dpi=120)
-            saved.append(out)
-            print(f"Saved plot: {out}")
+            figures[name] = make_fig()
         except Exception as e:
             print(f"  could not generate '{name}' plot ({type(e).__name__}: {e})")
+    if not figures:
+        return []
+
+    saved = []
+    if tc.backend == "plotly":
+        # Combine all charts into a single self-contained HTML report.
+        out = out_dir / f"{stem}_charts.html"
+        T3COCharts.write_html_report(list(figures.values()), out)
+        saved.append(out)
+        print(f"Saved plots: {out}")
+    else:
+        for name, fig in figures.items():
+            out = out_dir / f"{stem}_{name}.png"
+            fig.savefig(out, bbox_inches="tight", dpi=120)
+            saved.append(out)
+            print(f"Saved plot: {out}")
     return saved
 
 

--- a/src/t3co/demos/visualization_demo.py
+++ b/src/t3co/demos/visualization_demo.py
@@ -89,7 +89,6 @@ def render(results_df: pd.DataFrame, backend: str) -> None:
         return
 
     print(f"\n[{backend}] available group columns: {tc.group_columns}")
-    ext = "html" if backend == "plotly" else "png"
 
     tco_fig = tc.generate_tco_plots(
         x_group_col="vehicle_fuel_type",
@@ -101,14 +100,18 @@ def render(results_df: pd.DataFrame, backend: str) -> None:
     hist_fig = tc.generate_histogram(
         hist_col="discounted_tco_dol", n_bins=5, show_pct=True
     )
+    figs = [("tco_breakdown", tco_fig), ("violin", violin_fig), ("histogram", hist_fig)]
 
-    for name, fig in [("tco_breakdown", tco_fig), ("violin", violin_fig), ("histogram", hist_fig)]:
-        out = OUT_DIR / f"{name}_{backend}.{ext}"
-        if backend == "plotly":
-            fig.write_html(out)
-        else:
-            fig.savefig(out, bbox_inches="tight", dpi=120)
+    if backend == "plotly":
+        # All charts combined into a single self-contained HTML report.
+        out = OUT_DIR / "charts_plotly.html"
+        T3COCharts.write_html_report([fig for _, fig in figs], out)
         print(f"  wrote {out}")
+    else:
+        for name, fig in figs:
+            out = OUT_DIR / f"{name}_matplotlib.png"
+            fig.savefig(out, bbox_inches="tight", dpi=120)
+            print(f"  wrote {out}")
 
 
 def main() -> None:

--- a/src/t3co/demos/visualization_demo.py
+++ b/src/t3co/demos/visualization_demo.py
@@ -1,0 +1,129 @@
+"""
+Demo for the T3CO visualization module (:class:`t3co.visualize.charts.T3COCharts`).
+
+This script builds a small T3CO results DataFrame from the bundled demo inputs
+(without requiring FASTSim or the optimizer), then renders the three available
+plots with both backends:
+
+* ``backend="matplotlib"`` -> static PNG files
+* ``backend="plotly"``     -> interactive, self-contained HTML files
+
+A backend whose optional dependencies are not installed is skipped with a note;
+install them with ``pip install t3co_go[viz]``.
+
+Run from the repository root::
+
+    python src/t3co/demos/visualization_demo.py
+
+Outputs are written to ``./results/visualization/`` (relative to the working dir).
+"""
+
+from pathlib import Path
+
+import pandas as pd
+
+from t3co.energy_models import energy
+from t3co.input_data import scenario, vehicle
+from t3co.tco import ledger
+from t3co.visualize.charts import T3COCharts
+
+INPUTS_DIR = Path(__file__).resolve().parents[1] / "resources" / "inputs"
+SCENARIO_FILE = INPUTS_DIR / "Demo_FY22_scenario_assumptions.csv"
+VEHICLE_FILE = INPUTS_DIR / "Demo_FY22_vehicle_model_assumptions.csv"
+
+OUT_DIR = Path.cwd() / "results" / "visualization"
+
+
+def build_demo_results(max_per_fuel: int = 2, max_total: int = 12) -> pd.DataFrame:
+    """
+    Builds a small results DataFrame by running a handful of selections that span
+    the available fuel types in the demo scenario file.
+
+    Args:
+        max_per_fuel (int): Max selections to include per distinct fuel type.
+        max_total (int): Overall cap on the number of selections.
+
+    Returns:
+        pd.DataFrame: Flattened T3CO results, one row per selection.
+    """
+    scenario_df = pd.read_csv(SCENARIO_FILE)
+
+    # Pick a spread of selections across fuel types for a varied breakdown chart.
+    selections = []
+    for _, group in scenario_df.groupby("fuel_type"):
+        selections.extend(group["selection"].head(max_per_fuel).tolist())
+    selections = sorted(selections)[:max_total]
+
+    rows = []
+    for sel in selections:
+        try:
+            veh = vehicle.Vehicle().from_csv(selection=sel, vehicle_db_file=VEHICLE_FILE)
+            veh.set_veh_kg()
+            scen = scenario.Scenario().from_csv(selection=sel, scenario_file=SCENARIO_FILE)
+            eng = energy.Energy(mpgge=4.0, primary_fuel_range_mi=200.0)
+            row = ledger.Ledger(vehicle=veh, scenario=scen, energy=eng).to_dict(
+                flatten=True, exclude_list_fields=True
+            )
+            rows.append(row)
+        except Exception as e:  # keep the demo resilient to any single bad selection
+            print(f"  skipped selection {sel}: {type(e).__name__}: {e}")
+
+    if not rows:
+        raise RuntimeError("Could not build any demo results rows.")
+    print(f"Built results for selections: {selections}")
+    return pd.DataFrame(rows)
+
+
+def render(results_df: pd.DataFrame, backend: str) -> None:
+    """
+    Renders the three plots for one backend and writes them to ``OUT_DIR``.
+
+    Args:
+        results_df (pd.DataFrame): The T3CO results to plot.
+        backend (str): "matplotlib" (static PNG) or "plotly" (interactive HTML).
+    """
+    try:
+        tc = T3COCharts(results_df=results_df, backend=backend)
+    except ImportError as e:
+        print(f"\n[{backend}] skipped - {e}")
+        return
+
+    print(f"\n[{backend}] available group columns: {tc.group_columns}")
+    ext = "html" if backend == "plotly" else "png"
+
+    tco_fig = tc.generate_tco_plots(
+        x_group_col="vehicle_fuel_type",
+        y_group_col="None",
+        subplot_group_col="vehicle_type",
+        bar_width=0.7,
+    )
+    violin_fig = tc.generate_violin_plot(x_group_col="vehicle_fuel_type", y_group_col="mpgge")
+    hist_fig = tc.generate_histogram(
+        hist_col="discounted_tco_dol", n_bins=5, show_pct=True
+    )
+
+    for name, fig in [("tco_breakdown", tco_fig), ("violin", violin_fig), ("histogram", hist_fig)]:
+        out = OUT_DIR / f"{name}_{backend}.{ext}"
+        if backend == "plotly":
+            fig.write_html(out)
+        else:
+            fig.savefig(out, bbox_inches="tight", dpi=120)
+        print(f"  wrote {out}")
+
+
+def main() -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    results_df = build_demo_results()
+
+    results_csv = OUT_DIR / "visualization_demo_results.csv"
+    results_df.to_csv(results_csv, index=False)
+    print(f"Saved demo results to {results_csv}")
+
+    for backend in ("plotly", "matplotlib"):
+        render(results_df, backend)
+
+    print(f"\nDone. See {OUT_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/t3co/demos/visualization_demo.py
+++ b/src/t3co/demos/visualization_demo.py
@@ -103,9 +103,11 @@ def render(results_df: pd.DataFrame, backend: str) -> None:
     figs = [("tco_breakdown", tco_fig), ("violin", violin_fig), ("histogram", hist_fig)]
 
     if backend == "plotly":
-        # All charts combined into a single self-contained HTML report.
+        # All charts combined into a single self-contained HTML report, led by an
+        # interactive explorer with dropdowns to pick the x and y columns.
+        report_figs = [tc.generate_interactive_plot()] + [fig for _, fig in figs]
         out = OUT_DIR / "charts_plotly.html"
-        T3COCharts.write_html_report([fig for _, fig in figs], out)
+        T3COCharts.write_html_report(report_figs, out)
         print(f"  wrote {out}")
     else:
         for name, fig in figs:

--- a/src/t3co/visualize/__init__.py
+++ b/src/t3co/visualize/__init__.py
@@ -1,0 +1,5 @@
+"""T3CO visualization package."""
+
+from t3co.visualize.charts import T3COCharts
+
+__all__ = ["T3COCharts"]

--- a/src/t3co/visualize/charts.py
+++ b/src/t3co/visualize/charts.py
@@ -250,17 +250,32 @@ class T3COCharts:
         )
 
     def _require_matplotlib(self):
-        """Lazily imports the matplotlib/seaborn stack with a helpful error."""
+        """Lazily imports matplotlib with a helpful error.
+
+        matplotlib is a transitive dependency of pymoo (a core T3CO requirement),
+        so the cost-breakdown and histogram plots work on a base install. Only the
+        violin plot additionally needs seaborn (see ``_require_seaborn``).
+        """
         try:
             import matplotlib
             import matplotlib.pyplot as plt
-            import seaborn as sns
             from matplotlib.ticker import FuncFormatter
 
-            return matplotlib, plt, sns, FuncFormatter
+            return matplotlib, plt, FuncFormatter
         except ImportError as e:  # pragma: no cover - exercised via error path
             raise ImportError(
-                f"Static (matplotlib/seaborn) plotting is unavailable. {_VIZ_EXTRA_HINT}"
+                f"Static (matplotlib) plotting is unavailable. {_VIZ_EXTRA_HINT}"
+            ) from e
+
+    def _require_seaborn(self):
+        """Lazily imports seaborn (used only for violin plots) with a helpful error."""
+        try:
+            import seaborn as sns
+
+            return sns
+        except ImportError as e:  # pragma: no cover - exercised via error path
+            raise ImportError(
+                f"Violin plots require seaborn. {_VIZ_EXTRA_HINT}"
             ) from e
 
     def _require_plotly(self):
@@ -401,7 +416,7 @@ class T3COCharts:
         legend_pos,
         edgecolor,
     ):
-        _, plt, _, FuncFormatter = self._require_matplotlib()
+        _, plt, FuncFormatter = self._require_matplotlib()
 
         df = self.t3co_results
         cost_cols = self.present_cost_cols()
@@ -498,7 +513,8 @@ class T3COCharts:
         return fig
 
     def _generate_violin_mpl(self, x_group_col, y_group_col, fig_width, fig_height):
-        _, plt, sns, FuncFormatter = self._require_matplotlib()
+        _, plt, FuncFormatter = self._require_matplotlib()
+        sns = self._require_seaborn()
 
         df = self.t3co_results.copy()
         df[y_group_col] = pd.to_numeric(df[y_group_col], errors="coerce").round(5)
@@ -526,7 +542,7 @@ class T3COCharts:
         return fig
 
     def _generate_histogram_mpl(self, hist_col, n_bins, fig_width, fig_height, show_pct):
-        _, plt, _, _ = self._require_matplotlib()
+        _, plt, _ = self._require_matplotlib()
 
         df = self.t3co_results
         values = pd.to_numeric(df[hist_col], errors="coerce").dropna().round(4)

--- a/src/t3co/visualize/charts.py
+++ b/src/t3co/visualize/charts.py
@@ -1,1 +1,683 @@
+"""
+T3CO visualization module.
 
+This module ports the charting functionality from T3CO 1.0.x into the 2.0 results
+schema. It exposes a single :class:`T3COCharts` class that reads a T3CO results CSV
+(or DataFrame) and generates three plots - a TCO cost-breakdown chart, a violin
+plot, and a histogram.
+
+Each plot can be rendered with one of two interchangeable backends:
+
+* ``"matplotlib"`` (alias ``"seaborn"``) - static figures suitable for PNG/PDF export.
+* ``"plotly"`` - interactive figures suitable for self-contained HTML export.
+
+The plotting dependencies are optional. Install them alongside T3CO with::
+
+    pip install t3co_go[viz]
+"""
+
+from pathlib import Path
+from textwrap import wrap
+from typing import List, Union
+
+import numpy as np
+import pandas as pd
+
+# Pip extra that provides the optional plotting backends.
+_VIZ_EXTRA_HINT = (
+    "This requires the optional plotting dependencies. "
+    "Install them with: pip install t3co_go[viz]"
+)
+
+DEFAULT_RESULTS_GUIDE = (
+    Path(__file__).parents[1] / "resources" / "visualization" / "t3co_outputs_guide.csv"
+)
+
+
+class T3COCharts:
+    """
+    Generates plots from T3CO results to gain insights from the Total Cost of
+    Ownership outputs.
+
+    The class accepts a T3CO results CSV file or DataFrame (as produced by
+    ``Ledger.to_csv``/``Ledger.to_df`` or the ``t3co.cli.sweep`` runner) and
+    normalizes the 2.0 flattened column names into the canonical names used by
+    the plots and the ``t3co_outputs_guide.csv`` labels guide.
+    """
+
+    t3co_results: pd.DataFrame
+    results_guide: pd.DataFrame
+    value_cols: List[str]
+    backend: str
+
+    # Cost components shown (stacked) in the TCO breakdown plot, with their colors.
+    # These are bare Ledger fields and survive the 2.0 flattening unchanged.
+    COST_COLS = {
+        "residual_cost_dol": "#6C7B8B",
+        "glider_cost_dol": "#8b7355",
+        "fuel_converter_cost_dol": "#228B22",
+        "fuel_storage_cost_dol": "#8B4513",
+        "motor_control_power_elecs_cost_dol": "#1874CD",
+        "plug_cost_dol": "#6A5ACD",
+        "battery_cost_dol": "#7EC0EE",
+        "purchase_tax_dol": "#CD5B45",
+        "insurance_cost_dol": "#CDC673",
+        "total_maintenance_cost_dol": "#DAA520",
+        "total_fuel_cost_dol": "#4682B4",
+        "fueling_dwell_labor_cost_dol": "#CD2626",
+        "discounted_downtime_oppy_cost_dol": "#8B0000",
+        "payload_capacity_cost_dol": "#CD8C95",
+    }
+
+    # Weight-class boundaries (kg, upper-inclusive) used to derive vehicle_weight_class.
+    _WEIGHT_CLASS_BINS = [0, 2722, 3856, 4536, 6350, 7257, 8845, 11793, 14969, 50000]
+    _WEIGHT_CLASS_LABELS = [
+        "Class 1",
+        "Class 2a",
+        "Class 2b",
+        "Class 3",
+        "Class 4",
+        "Class 5",
+        "Class 6",
+        "Class 7",
+        "Class 8",
+    ]
+
+    # Maps a canonical grouping column to the 2.0 flattened source columns it may
+    # come from (first match wins). Lets the same code consume both a freshly
+    # flattened sweep CSV (prefixed names) and a pre-normalized one (bare names).
+    _GROUP_COL_SOURCES = {
+        "vehicle_fuel_type": ["vehicle_fuel_type", "scenario_fuel_type", "fuel_type"],
+        "veh_year": ["veh_year", "scenario_veh_year"],
+        "vehicle_type": ["vehicle_type", "scenario_vocation", "vocation"],
+        "veh_pt_type": ["veh_pt_type", "vehicle_veh_pt_type"],
+    }
+
+    def __init__(
+        self,
+        filename: Union[str, Path] = None,
+        results_df: pd.DataFrame = None,
+        backend: str = "matplotlib",
+        results_guide: Union[str, Path] = DEFAULT_RESULTS_GUIDE,
+    ) -> None:
+        """
+        Initializes the T3COCharts object from a DataFrame or a CSV file path.
+
+        Args:
+            filename (str | Path, optional): Filepath to a T3CO results CSV file. Defaults to None.
+            results_df (pd.DataFrame, optional): T3CO results DataFrame. Defaults to None.
+            backend (str, optional): Rendering backend. One of "matplotlib" (alias "seaborn")
+                for static figures or "plotly" for interactive HTML figures. Defaults to "matplotlib".
+            results_guide (str | Path, optional): Path to t3co_outputs_guide.csv containing parameter
+                descriptions and axis labels. Defaults to the bundled resource file.
+
+        Raises:
+            ValueError: If neither filename nor results_df is provided, or backend is unknown.
+        """
+        self.backend = self._normalize_backend(backend)
+
+        if filename is not None:
+            self.from_file(filename)
+        elif results_df is not None:
+            self.from_df(results_df)
+        else:
+            raise ValueError("Provide either 'filename' or 'results_df'.")
+
+        self.results_guide = pd.read_csv(results_guide)
+        self.full_form_dict = dict(
+            zip(
+                self.results_guide["t3co_output_parameter"],
+                self.results_guide["full_form"],
+            )
+        )
+        self.value_cols = list(
+            self.results_guide.loc[
+                self.results_guide["data_type"] == "float", "t3co_output_parameter"
+            ].values
+        )
+
+        self._normalize_columns()
+
+        # Cast plotted numeric columns to float (results CSVs may load as object/str).
+        for col in list(self.present_cost_cols().keys()) + ["discounted_tco_dol"]:
+            if col in self.t3co_results.columns:
+                self.t3co_results[col] = (
+                    pd.to_numeric(self.t3co_results[col], errors="coerce").astype(float).round(2)
+                )
+
+        # Group-by options exposed for the TCO plot, limited to columns actually present.
+        candidate_groups = [
+            "vehicle_weight_class",
+            "veh_year",
+            "vehicle_type",
+            "tech_progress",
+            "vehicle_fuel_type",
+            "veh_pt_type",
+        ]
+        self.group_columns = ["None"] + [
+            c for c in candidate_groups if c in self.t3co_results.columns
+        ]
+        self.edgecolors = ["none", "black", "gray", "white"]
+
+    # ------------------------------------------------------------------ #
+    # Data loading / access
+    # ------------------------------------------------------------------ #
+    def from_file(self, filename: Union[str, Path]) -> None:
+        """Reads a T3CO results CSV file into ``self.t3co_results``."""
+        self.t3co_results = pd.read_csv(filename)
+
+    def from_df(self, results_df: pd.DataFrame) -> None:
+        """Loads ``self.t3co_results`` from an existing DataFrame (a copy is taken)."""
+        self.t3co_results = results_df.copy().reset_index(drop=True)
+
+    def to_df(self) -> pd.DataFrame:
+        """Returns the (normalized) results DataFrame."""
+        return self.t3co_results
+
+    def present_cost_cols(self) -> dict:
+        """Returns the subset of cost columns (with colors) present in the results."""
+        return {
+            k: v for k, v in self.COST_COLS.items() if k in self.t3co_results.columns
+        }
+
+    # ------------------------------------------------------------------ #
+    # Schema normalization
+    # ------------------------------------------------------------------ #
+    def _normalize_columns(self) -> None:
+        """
+        Creates canonical grouping columns expected by the plots from the 2.0
+        flattened results schema.
+
+        The 2.0 results come from ``Ledger.to_dict(include_prefix=True)`` which
+        prefixes nested objects (e.g. ``scenario_fuel_type``). This maps those to
+        the bare names the plots and the labels guide use, and derives
+        ``vehicle_weight_class`` from GVWR. All steps are guarded so a CSV that
+        already uses bare names is left untouched.
+        """
+        df = self.t3co_results
+
+        # Map prefixed/source columns onto canonical names when not already present.
+        for canonical, sources in self._GROUP_COL_SOURCES.items():
+            if canonical in df.columns:
+                continue
+            for src in sources:
+                if src in df.columns:
+                    df[canonical] = df[src]
+                    break
+
+        # Derive vehicle_weight_class from GVWR if not already provided.
+        if "vehicle_weight_class" not in df.columns:
+            gvwr_col = next(
+                (c for c in ["scenario_gvwr_kg", "gvwr_kg"] if c in df.columns), None
+            )
+            if gvwr_col is not None:
+                df["vehicle_weight_class"] = pd.cut(
+                    pd.to_numeric(df[gvwr_col], errors="coerce"),
+                    bins=self._WEIGHT_CLASS_BINS,
+                    labels=self._WEIGHT_CLASS_LABELS,
+                    right=True,
+                ).astype("object")
+
+        # tech_progress is not a 2.0 field; best-effort parse from scenario_name
+        # of the legacy "Vocation Type (FuelType, TechProgress)" format.
+        if "tech_progress" not in df.columns and "scenario_name" in df.columns:
+            try:
+                parsed = (
+                    df["scenario_name"]
+                    .str.split("(")
+                    .apply(lambda x: x[1].split(",")[-1].split(")")[0].strip())
+                )
+                if parsed.notna().all() and (parsed.str.len() > 0).all():
+                    df["tech_progress"] = parsed
+            except (IndexError, AttributeError):
+                pass  # scenario_name not in the legacy format; skip tech_progress.
+
+        self.t3co_results = df
+
+    # ------------------------------------------------------------------ #
+    # Backend helpers
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _normalize_backend(backend: str) -> str:
+        """Validates and canonicalizes the backend name."""
+        backend = (backend or "").lower()
+        if backend in ("matplotlib", "seaborn", "mpl"):
+            return "matplotlib"
+        if backend in ("plotly", "html"):
+            return "plotly"
+        raise ValueError(
+            f"Unknown backend {backend!r}. Use 'matplotlib' (static) or 'plotly' (interactive)."
+        )
+
+    def _require_matplotlib(self):
+        """Lazily imports the matplotlib/seaborn stack with a helpful error."""
+        try:
+            import matplotlib
+            import matplotlib.pyplot as plt
+            import seaborn as sns
+            from matplotlib.ticker import FuncFormatter
+
+            return matplotlib, plt, sns, FuncFormatter
+        except ImportError as e:  # pragma: no cover - exercised via error path
+            raise ImportError(
+                f"Static (matplotlib/seaborn) plotting is unavailable. {_VIZ_EXTRA_HINT}"
+            ) from e
+
+    def _require_plotly(self):
+        """Lazily imports the plotly stack with a helpful error."""
+        try:
+            import plotly.express as px
+            import plotly.graph_objects as go
+            from plotly.subplots import make_subplots
+
+            return go, px, make_subplots
+        except ImportError as e:  # pragma: no cover - exercised via error path
+            raise ImportError(
+                f"Interactive (plotly) plotting is unavailable. {_VIZ_EXTRA_HINT}"
+            ) from e
+
+    def _label(self, col: str) -> str:
+        """Returns the human-readable label for a column, falling back to its name."""
+        return self.full_form_dict.get(col, col)
+
+    def _group_values(self, group_col: str) -> list:
+        """Returns the distinct values to iterate over for a grouping column."""
+        if group_col == "None":
+            return [None]
+        return list(self.t3co_results[group_col].unique())
+
+    # ------------------------------------------------------------------ #
+    # Public plotting API (backend-dispatching)
+    # ------------------------------------------------------------------ #
+    def generate_tco_plots(
+        self,
+        x_group_col: str = "None",
+        y_group_col: str = "None",
+        subplot_group_col: str = "vehicle_fuel_type",
+        fig_x_size: int = 8,
+        fig_y_size: int = 8,
+        bar_width: float = 0.8,
+        legend_pos: float = 0.25,
+        edgecolor: str = "none",
+    ):
+        """
+        Generates a TCO cost-breakdown plot, optionally as a grid of subplots
+        grouped by ``x_group_col`` (columns) and ``y_group_col`` (rows).
+
+        Within each cell, stacked bars show every cost component (colored per
+        ``COST_COLS``) and red diamond markers overlay the discounted TCO.
+
+        Args:
+            x_group_col (str, optional): Column to group subplot columns. Use "None" for no grouping.
+            y_group_col (str, optional): Column to group subplot rows. Use "None" for no grouping.
+            subplot_group_col (str, optional): Column shown as bars within each cell when grouped.
+                Defaults to "vehicle_fuel_type".
+            fig_x_size (int, optional): Figure width factor per subplot column. Defaults to 8.
+            fig_y_size (int, optional): Figure height factor per subplot row. Defaults to 8.
+            bar_width (float, optional): Bar width fraction (0-1). Defaults to 0.8.
+            legend_pos (float, optional): Legend horizontal offset (matplotlib only). Defaults to 0.25.
+            edgecolor (str, optional): Bar edge color (matplotlib only). Defaults to "none".
+
+        Returns:
+            matplotlib.figure.Figure | plotly.graph_objects.Figure: The TCO breakdown figure.
+        """
+        if "discounted_tco_dol" not in self.t3co_results.columns:
+            raise KeyError("Results are missing required column 'discounted_tco_dol'.")
+        if self.backend == "plotly":
+            return self._generate_tco_plots_plotly(
+                x_group_col, y_group_col, subplot_group_col, fig_x_size, fig_y_size, bar_width
+            )
+        return self._generate_tco_plots_mpl(
+            x_group_col,
+            y_group_col,
+            subplot_group_col,
+            fig_x_size,
+            fig_y_size,
+            bar_width,
+            legend_pos,
+            edgecolor,
+        )
+
+    def generate_violin_plot(
+        self,
+        x_group_col: str,
+        y_group_col: str = "discounted_tco_dol",
+        fig_width: float = 8,
+        fig_height: float = 5,
+    ):
+        """
+        Generates a violin plot of ``y_group_col`` distribution across ``x_group_col`` categories.
+
+        Args:
+            x_group_col (str): Categorical column to group on the x-axis.
+            y_group_col (str, optional): Numeric column on the y-axis. Defaults to "discounted_tco_dol".
+            fig_width (float, optional): Figure width (inches for matplotlib). Defaults to 8.
+            fig_height (float, optional): Figure height (inches for matplotlib). Defaults to 5.
+
+        Returns:
+            matplotlib.figure.Figure | plotly.graph_objects.Figure: The violin figure.
+        """
+        if self.backend == "plotly":
+            return self._generate_violin_plotly(x_group_col, y_group_col, fig_width, fig_height)
+        return self._generate_violin_mpl(x_group_col, y_group_col, fig_width, fig_height)
+
+    def generate_histogram(
+        self,
+        hist_col: str,
+        n_bins: int,
+        fig_width: float = 8,
+        fig_height: float = 5,
+        show_pct: bool = False,
+    ):
+        """
+        Generates a histogram of ``hist_col``.
+
+        Args:
+            hist_col (str): Column to plot.
+            n_bins (int): Number of bins.
+            fig_width (float, optional): Figure width (inches for matplotlib). Defaults to 8.
+            fig_height (float, optional): Figure height (inches for matplotlib). Defaults to 5.
+            show_pct (bool, optional): If True, the y-axis shows percentage of scenarios
+                instead of a count. Defaults to False.
+
+        Returns:
+            matplotlib.figure.Figure | plotly.graph_objects.Figure: The histogram figure.
+        """
+        if self.backend == "plotly":
+            return self._generate_histogram_plotly(hist_col, n_bins, fig_width, fig_height, show_pct)
+        return self._generate_histogram_mpl(hist_col, n_bins, fig_width, fig_height, show_pct)
+
+    # ------------------------------------------------------------------ #
+    # matplotlib / seaborn implementations
+    # ------------------------------------------------------------------ #
+    def _generate_tco_plots_mpl(
+        self,
+        x_group_col,
+        y_group_col,
+        subplot_group_col,
+        fig_x_size,
+        fig_y_size,
+        bar_width,
+        legend_pos,
+        edgecolor,
+    ):
+        _, plt, _, FuncFormatter = self._require_matplotlib()
+
+        df = self.t3co_results
+        cost_cols = self.present_cost_cols()
+        ycols = list(cost_cols.keys())
+        colors = list(cost_cols.values())
+        disc_label = self._label("discounted_tco_dol")
+        currency = FuncFormatter(lambda v, p: "$" + format(int(v), ","))
+        fontsize = 14
+        grouped = x_group_col != "None" or y_group_col != "None"
+
+        x_groups = self._group_values(x_group_col)
+        y_groups = self._group_values(y_group_col)
+        nrows, ncols = len(y_groups), len(x_groups)
+
+        fig, axes = plt.subplots(
+            nrows,
+            ncols,
+            sharey=True,
+            squeeze=False,
+            figsize=(
+                min(4 + ncols * fig_x_size, 50),
+                min(4 + nrows * fig_y_size, 50),
+            ),
+        )
+
+        for i, yv in enumerate(y_groups):
+            for j, xv in enumerate(x_groups):
+                ax = axes[i][j]
+                sub = df
+                if x_group_col != "None":
+                    sub = sub[sub[x_group_col] == xv]
+                if y_group_col != "None":
+                    sub = sub[sub[y_group_col] == yv]
+                if sub.empty:
+                    ax.set_axis_off()
+                    continue
+
+                xpos = range(len(sub))
+                ax.scatter(
+                    list(xpos),
+                    sub["discounted_tco_dol"],
+                    color="red",
+                    marker="D",
+                    s=80,
+                    zorder=3,
+                    label=disc_label,
+                )
+                sub.plot.bar(
+                    y=ycols,
+                    stacked=True,
+                    ax=ax,
+                    width=bar_width,
+                    color=colors,
+                    legend=False,
+                    edgecolor=edgecolor if edgecolor in self.edgecolors else "none",
+                    alpha=0.85,
+                )
+                ax.get_yaxis().set_major_formatter(currency)
+                ax.minorticks_on()
+
+                if grouped and subplot_group_col in sub.columns:
+                    ticklabels = [str(v) for v in sub[subplot_group_col]]
+                else:
+                    ticklabels = ["\n".join(wrap(str(s), 25)) for s in sub["scenario_name"]]
+                ax.set_xticks(list(range(len(sub))))
+                ax.set_xticklabels(ticklabels, rotation=90, fontsize=fontsize * 0.7)
+                ax.set_xlim(-0.5, len(sub) - 0.5)
+
+                if x_group_col != "None" and i == nrows - 1:
+                    ax.set_xlabel(str(xv), fontsize=fontsize, labelpad=8)
+                if y_group_col != "None" and j == ncols - 1:
+                    ax2 = ax.twinx()
+                    ax2.set_yticks([])
+                    ax2.set_ylabel(str(yv), fontsize=fontsize, labelpad=8)
+
+        legend_labels = [disc_label] + [self._label(c) for c in ycols]
+        handles, _ = axes[0][0].get_legend_handles_labels()
+        fig.legend(
+            handles,
+            legend_labels,
+            loc="center right",
+            bbox_to_anchor=(1 + legend_pos, 0.5),
+            fontsize=fontsize,
+        )
+        fig.supylabel(r"Cost [$]", fontsize=fontsize)
+        if x_group_col != "None":
+            fig.supxlabel(self._label(x_group_col), fontsize=fontsize)
+        fig.suptitle(
+            "Total Cost of Ownership Breakdown",
+            fontsize=fontsize * 1.4,
+            fontweight="bold",
+        )
+        fig.tight_layout()
+        return fig
+
+    def _generate_violin_mpl(self, x_group_col, y_group_col, fig_width, fig_height):
+        _, plt, sns, FuncFormatter = self._require_matplotlib()
+
+        df = self.t3co_results.copy()
+        df[y_group_col] = pd.to_numeric(df[y_group_col], errors="coerce").round(5)
+        fig, ax = plt.subplots(1, 1, figsize=(fig_width, fig_height))
+        sns.violinplot(
+            x=x_group_col,
+            y=y_group_col,
+            data=df,
+            ax=ax,
+            palette="colorblind",
+            cut=0,
+            density_norm="count",
+            inner="quart",
+            hue=x_group_col,
+            legend=False,
+        )
+        if "dol" in y_group_col:
+            ax.get_yaxis().set_major_formatter(
+                FuncFormatter(lambda v, p: "$" + format(int(v), ","))
+            )
+        ax.set_title("Violin Plot", fontsize=15, fontweight="bold")
+        ax.set_xlabel(self._label(x_group_col))
+        ax.set_ylabel(self._label(y_group_col))
+        fig.tight_layout()
+        return fig
+
+    def _generate_histogram_mpl(self, hist_col, n_bins, fig_width, fig_height, show_pct):
+        _, plt, _, _ = self._require_matplotlib()
+
+        df = self.t3co_results
+        values = pd.to_numeric(df[hist_col], errors="coerce").dropna().round(4)
+        fig, ax = plt.subplots(1, 1, figsize=(fig_width, fig_height))
+        if len(values) > 0:
+            if show_pct:
+                hist, bins = np.histogram(np.array(values), bins=n_bins)
+                ax.bar(
+                    bins[:-1],
+                    hist.astype(np.float32) / hist.sum() * 100,
+                    width=(bins[1] - bins[0]),
+                    align="edge",
+                )
+                ax.set_ylabel("Percentage of Scenarios [%]")
+            else:
+                ax.hist(x=values, bins=n_bins)
+                ax.set_ylabel("Number of Scenarios")
+            ax.set_title("Histogram Plot", fontsize=14, fontweight="bold")
+            ax.set_xlabel(self._label(hist_col))
+        fig.tight_layout()
+        return fig
+
+    # ------------------------------------------------------------------ #
+    # plotly implementations
+    # ------------------------------------------------------------------ #
+    def _generate_tco_plots_plotly(
+        self, x_group_col, y_group_col, subplot_group_col, fig_x_size, fig_y_size, bar_width
+    ):
+        go, _, make_subplots = self._require_plotly()
+
+        df = self.t3co_results
+        cost_cols = self.present_cost_cols()
+        grouped = x_group_col != "None" or y_group_col != "None"
+
+        x_groups = self._group_values(x_group_col)
+        y_groups = self._group_values(y_group_col)
+        nrows, ncols = len(y_groups), len(x_groups)
+
+        fig = make_subplots(
+            rows=nrows,
+            cols=ncols,
+            shared_yaxes=True,
+            column_titles=[str(x) for x in x_groups] if x_group_col != "None" else None,
+            row_titles=[str(y) for y in y_groups] if y_group_col != "None" else None,
+            horizontal_spacing=0.04,
+            vertical_spacing=0.08,
+        )
+
+        shown = set()
+        for i, yv in enumerate(y_groups):
+            for j, xv in enumerate(x_groups):
+                sub = df
+                if x_group_col != "None":
+                    sub = sub[sub[x_group_col] == xv]
+                if y_group_col != "None":
+                    sub = sub[sub[y_group_col] == yv]
+                if sub.empty:
+                    continue
+
+                if grouped and subplot_group_col in sub.columns:
+                    xvals = [str(v) for v in sub[subplot_group_col]]
+                else:
+                    xvals = [str(v) for v in sub["scenario_name"]]
+
+                for col, color in cost_cols.items():
+                    fig.add_trace(
+                        go.Bar(
+                            x=xvals,
+                            y=sub[col],
+                            name=self._label(col),
+                            marker_color=color,
+                            legendgroup=col,
+                            showlegend=col not in shown,
+                        ),
+                        row=i + 1,
+                        col=j + 1,
+                    )
+                    shown.add(col)
+
+                fig.add_trace(
+                    go.Scatter(
+                        x=xvals,
+                        y=sub["discounted_tco_dol"],
+                        mode="markers",
+                        name=self._label("discounted_tco_dol"),
+                        marker=dict(color="red", symbol="diamond", size=9),
+                        legendgroup="_disc_tco",
+                        showlegend="_disc_tco" not in shown,
+                    ),
+                    row=i + 1,
+                    col=j + 1,
+                )
+                shown.add("_disc_tco")
+
+        fig.update_layout(
+            barmode="stack",
+            bargap=max(0.0, 1.0 - bar_width),
+            title=dict(text="Total Cost of Ownership Breakdown", x=0.5, font=dict(size=20)),
+            legend_title_text="Cost Components",
+            width=min(400 + ncols * fig_x_size * 60, 2400),
+            height=min(300 + nrows * fig_y_size * 55, 2000),
+        )
+        fig.update_yaxes(tickprefix="$", tickformat=",.0f")
+        fig.update_yaxes(title_text="Cost [$]", row=(nrows + 1) // 2, col=1)
+        if x_group_col != "None":
+            fig.update_xaxes(title_text=self._label(x_group_col), row=nrows, col=(ncols + 1) // 2)
+        return fig
+
+    def _generate_violin_plotly(self, x_group_col, y_group_col, fig_width, fig_height):
+        _, px, _ = self._require_plotly()
+
+        df = self.t3co_results.copy()
+        df[y_group_col] = pd.to_numeric(df[y_group_col], errors="coerce")
+        fig = px.violin(
+            df,
+            x=x_group_col,
+            y=y_group_col,
+            color=x_group_col,
+            box=True,
+            points="all",
+        )
+        if "dol" in y_group_col:
+            fig.update_yaxes(tickprefix="$", tickformat=",.0f")
+        fig.update_layout(
+            title=dict(text="Violin Plot", x=0.5, font=dict(size=18)),
+            xaxis_title=self._label(x_group_col),
+            yaxis_title=self._label(y_group_col),
+            width=int(fig_width * 96),
+            height=int(fig_height * 96),
+            showlegend=False,
+        )
+        return fig
+
+    def _generate_histogram_plotly(self, hist_col, n_bins, fig_width, fig_height, show_pct):
+        go, _, _ = self._require_plotly()
+
+        df = self.t3co_results.copy()
+        values = pd.to_numeric(df[hist_col], errors="coerce")
+        fig = go.Figure(
+            go.Histogram(
+                x=values,
+                nbinsx=n_bins,
+                histnorm="percent" if show_pct else None,
+            )
+        )
+        fig.update_layout(
+            title=dict(text="Histogram Plot", x=0.5, font=dict(size=18)),
+            xaxis_title=self._label(hist_col),
+            yaxis_title="Percentage of Scenarios [%]" if show_pct else "Number of Scenarios",
+            width=int(fig_width * 96),
+            height=int(fig_height * 96),
+            bargap=0.05,
+        )
+        return fig

--- a/src/t3co/visualize/charts.py
+++ b/src/t3co/visualize/charts.py
@@ -402,6 +402,37 @@ class T3COCharts:
             return self._generate_histogram_plotly(hist_col, n_bins, fig_width, fig_height, show_pct)
         return self._generate_histogram_mpl(hist_col, n_bins, fig_width, fig_height, show_pct)
 
+    @staticmethod
+    def write_html_report(figures: list, output_path: Union[str, Path]) -> Path:
+        """
+        Writes multiple Plotly figures into a single self-contained HTML file.
+
+        The figures are stacked vertically in one page. The Plotly library is
+        embedded once (with the first figure) and reused by the rest, so the
+        report stays fully offline-viewable without inflating to N copies.
+
+        Args:
+            figures (list): Plotly figures to include in the report.
+            output_path (str | Path): Destination ``.html`` file.
+
+        Returns:
+            Path: The written file path.
+        """
+        import plotly.io as pio
+
+        blocks = [
+            pio.to_html(fig, full_html=False, include_plotlyjs=(i == 0))
+            for i, fig in enumerate(figures)
+        ]
+        html = (
+            "<!DOCTYPE html>\n<html><head><meta charset='utf-8'/></head>\n<body>\n"
+            + "\n".join(blocks)
+            + "\n</body></html>\n"
+        )
+        output_path = Path(output_path)
+        output_path.write_text(html, encoding="utf-8")
+        return output_path
+
     # ------------------------------------------------------------------ #
     # matplotlib / seaborn implementations
     # ------------------------------------------------------------------ #

--- a/src/t3co/visualize/charts.py
+++ b/src/t3co/visualize/charts.py
@@ -402,6 +402,133 @@ class T3COCharts:
             return self._generate_histogram_plotly(hist_col, n_bins, fig_width, fig_height, show_pct)
         return self._generate_histogram_mpl(hist_col, n_bins, fig_width, fig_height, show_pct)
 
+    def generate_interactive_plot(
+        self,
+        default_x: str = "vehicle_fuel_type",
+        default_y: str = "discounted_tco_dol",
+        x_cols: List[str] = None,
+        y_cols: List[str] = None,
+    ):
+        """
+        Generates an interactive Plotly scatter with dropdown menus to choose the
+        x- and y-axis columns on the rendered HTML page.
+
+        This is an interactive-only chart and always uses Plotly, regardless of
+        the configured backend. Each dropdown swaps the axis data client-side, so
+        it works in a static, self-contained HTML file.
+
+        Args:
+            default_x (str, optional): Column selected on the x-axis initially. Defaults to "vehicle_fuel_type".
+            default_y (str, optional): Column selected on the y-axis initially. Defaults to "discounted_tco_dol".
+            x_cols (list[str], optional): Columns offered in the x dropdown. Defaults to the grouping
+                columns followed by the numeric output columns present in the results.
+            y_cols (list[str], optional): Columns offered in the y dropdown. Defaults to the numeric
+                output columns followed by the grouping columns present in the results.
+
+        Returns:
+            plotly.graph_objects.Figure: The interactive explorer figure.
+        """
+        go, _, _ = self._require_plotly()
+        df = self.t3co_results
+
+        grouping = [c for c in self.group_columns if c != "None" and c in df.columns]
+        numeric = [c for c in self.value_cols if c in df.columns]
+        numeric_set = set(numeric)
+
+        x_candidates = x_cols or list(dict.fromkeys(grouping + numeric))
+        y_candidates = y_cols or list(dict.fromkeys(numeric + grouping))
+        if not x_candidates or not y_candidates:
+            raise ValueError("No plottable columns available for the interactive plot.")
+        if default_x not in x_candidates:
+            default_x = x_candidates[0]
+        if default_y not in y_candidates:
+            default_y = y_candidates[0]
+
+        def values(col):
+            if col in numeric_set:
+                return pd.to_numeric(df[col], errors="coerce").tolist()
+            return df[col].astype(str).tolist()
+
+        def tickprefix(col):
+            return "$" if "dol" in col else ""
+
+        hover = (
+            df["scenario_name"].astype(str).tolist()
+            if "scenario_name" in df.columns
+            else None
+        )
+
+        fig = go.Figure(
+            go.Scatter(
+                x=values(default_x),
+                y=values(default_y),
+                mode="markers",
+                marker=dict(size=9, color="#1f77b4"),
+                text=hover,
+                hovertemplate=(
+                    "%{text}<br>%{x}<br>%{y}<extra></extra>" if hover else None
+                ),
+            )
+        )
+
+        def axis_buttons(candidates, axis):
+            return [
+                dict(
+                    label=self._label(c),
+                    method="update",
+                    args=[
+                        {axis: [values(c)]},
+                        {
+                            f"{axis}axis.title.text": self._label(c),
+                            f"{axis}axis.tickprefix": tickprefix(c),
+                        },
+                    ],
+                )
+                for c in candidates
+            ]
+
+        fig.update_layout(
+            title=dict(text="Results Explorer", x=0.5, font=dict(size=18)),
+            xaxis_title=self._label(default_x),
+            yaxis_title=self._label(default_y),
+            xaxis_tickprefix=tickprefix(default_x),
+            yaxis_tickprefix=tickprefix(default_y),
+            margin=dict(t=150),
+            updatemenus=[
+                dict(
+                    buttons=axis_buttons(x_candidates, "x"),
+                    active=x_candidates.index(default_x),
+                    direction="down",
+                    showactive=True,
+                    x=0.0,
+                    xanchor="left",
+                    y=1.22,
+                    yanchor="top",
+                ),
+                dict(
+                    buttons=axis_buttons(y_candidates, "y"),
+                    active=y_candidates.index(default_y),
+                    direction="down",
+                    showactive=True,
+                    x=0.32,
+                    xanchor="left",
+                    y=1.22,
+                    yanchor="top",
+                ),
+            ],
+            annotations=[
+                dict(
+                    text="X axis:", x=0.0, xref="paper", xanchor="left",
+                    y=1.28, yref="paper", yanchor="bottom", showarrow=False,
+                ),
+                dict(
+                    text="Y axis:", x=0.32, xref="paper", xanchor="left",
+                    y=1.28, yref="paper", yanchor="bottom", showarrow=False,
+                ),
+            ],
+        )
+        return fig
+
     @staticmethod
     def write_html_report(figures: list, output_path: Union[str, Path]) -> Path:
         """

--- a/tests/visualize/test_charts.py
+++ b/tests/visualize/test_charts.py
@@ -1,0 +1,121 @@
+"""Tests for the T3CO visualization module (t3co.visualize.charts.T3COCharts)."""
+
+import pandas as pd
+import pytest
+
+from t3co.visualize.charts import T3COCharts
+
+# Bare Ledger cost fields that survive 2.0 flattening unchanged.
+COST_COLS = list(T3COCharts.COST_COLS.keys())
+
+
+def _make_results() -> pd.DataFrame:
+    """Builds a small results frame using 2.0 *flattened* (prefixed) column names."""
+    n = 6
+    rows = []
+    fuels = ["diesel", "BEV", "HEV"]
+    for i in range(n):
+        row = {
+            "selection": i + 1,
+            # legacy-format scenario_name also exercises the tech_progress parse
+            "scenario_name": f"Class 8 Truck {i} ({fuels[i % 3]}, 2020, no program)",
+            # nested-object columns as emitted by Ledger.to_dict(include_prefix=True)
+            "scenario_fuel_type": fuels[i % 3],
+            "scenario_vocation": "Long haul" if i % 2 else "Regional",
+            "scenario_gvwr_kg": 36287.0 if i % 2 else 8000.0,
+            "scenario_veh_year": 2020,
+            "vehicle_veh_pt_type": fuels[i % 3],
+            "discounted_tco_dol": 100000.0 + i * 5000,
+            "mpgge": 4.0 + i * 0.1,
+        }
+        for k, col in enumerate(COST_COLS):
+            row[col] = 1000.0 * (k + 1) + i * 100
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture
+def results_df():
+    return _make_results()
+
+
+def test_normalizes_prefixed_columns(results_df):
+    tc = T3COCharts(results_df=results_df, backend="plotly")
+    df = tc.to_df()
+    # prefixed source columns are mapped onto canonical grouping names
+    assert "vehicle_fuel_type" in df.columns
+    assert "vehicle_type" in df.columns
+    assert "veh_pt_type" in df.columns
+    assert "vehicle_weight_class" in df.columns
+    assert list(df["vehicle_fuel_type"]) == list(results_df["scenario_fuel_type"])
+    # weight class derived from GVWR (36287 -> Class 8, 8000 -> Class 5)
+    assert set(df["vehicle_weight_class"]) == {"Class 8", "Class 5"}
+    # tech_progress parsed from the legacy scenario_name format
+    assert "tech_progress" in df.columns
+    assert set(df["tech_progress"]) == {"no program"}
+    # only present, valid group columns are exposed
+    assert tc.group_columns[0] == "None"
+    assert "vehicle_fuel_type" in tc.group_columns
+
+
+def test_bad_backend_raises(results_df):
+    with pytest.raises(ValueError):
+        T3COCharts(results_df=results_df, backend="ggplot")
+
+
+def test_requires_a_data_source():
+    with pytest.raises(ValueError):
+        T3COCharts()
+
+
+def test_missing_tco_column_raises():
+    df = _make_results().drop(columns=["discounted_tco_dol"])
+    tc = T3COCharts(results_df=df, backend="plotly")
+    with pytest.raises(KeyError):
+        tc.generate_tco_plots()
+
+
+# --------------------------- plotly backend --------------------------- #
+def test_plotly_figures(results_df):
+    go = pytest.importorskip("plotly.graph_objects")
+    tc = T3COCharts(results_df=results_df, backend="plotly")
+
+    tco = tc.generate_tco_plots(x_group_col="vehicle_fuel_type", subplot_group_col="vehicle_type")
+    violin = tc.generate_violin_plot(x_group_col="vehicle_fuel_type", y_group_col="mpgge")
+    hist = tc.generate_histogram(hist_col="discounted_tco_dol", n_bins=4, show_pct=True)
+
+    assert isinstance(tco, go.Figure)
+    assert isinstance(violin, go.Figure)
+    assert isinstance(hist, go.Figure)
+    # the TCO figure stacks one bar trace per cost component plus the TCO markers
+    assert any(t.type == "bar" for t in tco.data)
+    assert any(t.type == "scatter" for t in tco.data)
+
+
+def test_plotly_ungrouped_tco(results_df):
+    pytest.importorskip("plotly.graph_objects")
+    tc = T3COCharts(results_df=results_df, backend="plotly")
+    fig = tc.generate_tco_plots()  # no grouping
+    assert fig is not None
+
+
+# ------------------------- matplotlib backend ------------------------- #
+def test_matplotlib_figures(results_df):
+    mpl = pytest.importorskip("matplotlib")
+    mpl.use("Agg")  # headless backend for CI
+    from matplotlib.figure import Figure
+
+    tc = T3COCharts(results_df=results_df, backend="matplotlib")
+
+    tco = tc.generate_tco_plots(x_group_col="vehicle_fuel_type", subplot_group_col="vehicle_type")
+    violin = tc.generate_violin_plot(x_group_col="vehicle_fuel_type", y_group_col="mpgge")
+    hist = tc.generate_histogram(hist_col="discounted_tco_dol", n_bins=4)
+
+    assert isinstance(tco, Figure)
+    assert isinstance(violin, Figure)
+    assert isinstance(hist, Figure)
+
+
+def test_seaborn_alias_maps_to_matplotlib(results_df):
+    tc = T3COCharts(results_df=results_df, backend="seaborn")
+    assert tc.backend == "matplotlib"

--- a/tests/visualize/test_charts.py
+++ b/tests/visualize/test_charts.py
@@ -99,6 +99,23 @@ def test_plotly_ungrouped_tco(results_df):
     assert fig is not None
 
 
+def test_save_default_plots_cli_hook(tmp_path, results_df):
+    """The sweep --plot hook should write chart files next to a results CSV."""
+    pytest.importorskip("plotly.graph_objects")
+    from t3co.cli.sweep import save_default_plots
+
+    csv = tmp_path / "results.csv"
+    results_df.to_csv(csv, index=False)
+    saved = save_default_plots(csv, backend="plotly")
+
+    # breakdown + histogram (+ violin since the data has a fuel-type grouping)
+    assert len(saved) == 3
+    for path in saved:
+        assert path.exists()
+        assert path.suffix == ".html"
+        assert path.parent == tmp_path
+
+
 # ------------------------- matplotlib backend ------------------------- #
 def test_matplotlib_figures(results_df):
     mpl = pytest.importorskip("matplotlib")

--- a/tests/visualize/test_charts.py
+++ b/tests/visualize/test_charts.py
@@ -99,6 +99,23 @@ def test_plotly_ungrouped_tco(results_df):
     assert fig is not None
 
 
+def test_interactive_plot_has_xy_dropdowns(results_df):
+    pytest.importorskip("plotly.graph_objects")
+    tc = T3COCharts(results_df=results_df, backend="plotly")
+    fig = tc.generate_interactive_plot(default_x="vehicle_fuel_type", default_y="discounted_tco_dol")
+
+    # two dropdown menus: one for X, one for Y
+    menus = fig.layout.updatemenus
+    assert len(menus) == 2
+    # each dropdown offers a button per candidate column, and switching swaps axis data
+    for menu in menus:
+        assert len(menu.buttons) >= 2
+        assert menu.buttons[0].method == "update"
+    # the initial axes reflect the requested defaults
+    assert fig.layout.xaxis.title.text == tc._label("vehicle_fuel_type")
+    assert fig.layout.yaxis.title.text == tc._label("discounted_tco_dol")
+
+
 def test_save_default_plots_cli_hook(tmp_path, results_df):
     """The sweep --plot hook should write ONE combined HTML report next to the CSV."""
     pytest.importorskip("plotly.graph_objects")
@@ -108,14 +125,14 @@ def test_save_default_plots_cli_hook(tmp_path, results_df):
     results_df.to_csv(csv, index=False)
     saved = save_default_plots(csv, backend="plotly")
 
-    # all charts (breakdown + histogram + violin) combined into a single HTML file
+    # explorer + breakdown + histogram + violin, combined into a single HTML file
     assert len(saved) == 1
     report = saved[0]
     assert report.exists()
     assert report.suffix == ".html"
     assert report.parent == tmp_path
-    # the report holds three plots in one page
-    assert report.read_text().count('class="plotly-graph-div"') == 3
+    # the report holds four plots in one page (incl. the interactive explorer)
+    assert report.read_text().count('class="plotly-graph-div"') == 4
 
 
 def test_write_html_report_combines_plots(tmp_path, results_df):

--- a/tests/visualize/test_charts.py
+++ b/tests/visualize/test_charts.py
@@ -118,6 +118,8 @@ def test_save_default_plots_cli_hook(tmp_path, results_df):
 
 # ------------------------- matplotlib backend ------------------------- #
 def test_matplotlib_figures(results_df):
+    # matplotlib ships transitively with pymoo (a core dep), so the cost-breakdown
+    # and histogram plots work without the viz extra; only the violin needs seaborn.
     mpl = pytest.importorskip("matplotlib")
     mpl.use("Agg")  # headless backend for CI
     from matplotlib.figure import Figure
@@ -125,12 +127,21 @@ def test_matplotlib_figures(results_df):
     tc = T3COCharts(results_df=results_df, backend="matplotlib")
 
     tco = tc.generate_tco_plots(x_group_col="vehicle_fuel_type", subplot_group_col="vehicle_type")
-    violin = tc.generate_violin_plot(x_group_col="vehicle_fuel_type", y_group_col="mpgge")
     hist = tc.generate_histogram(hist_col="discounted_tco_dol", n_bins=4)
 
     assert isinstance(tco, Figure)
-    assert isinstance(violin, Figure)
     assert isinstance(hist, Figure)
+
+
+def test_matplotlib_violin_requires_seaborn(results_df):
+    pytest.importorskip("seaborn")  # seaborn is only needed for the violin plot
+    mpl = pytest.importorskip("matplotlib")
+    mpl.use("Agg")
+    from matplotlib.figure import Figure
+
+    tc = T3COCharts(results_df=results_df, backend="matplotlib")
+    violin = tc.generate_violin_plot(x_group_col="vehicle_fuel_type", y_group_col="mpgge")
+    assert isinstance(violin, Figure)
 
 
 def test_seaborn_alias_maps_to_matplotlib(results_df):

--- a/tests/visualize/test_charts.py
+++ b/tests/visualize/test_charts.py
@@ -100,7 +100,7 @@ def test_plotly_ungrouped_tco(results_df):
 
 
 def test_save_default_plots_cli_hook(tmp_path, results_df):
-    """The sweep --plot hook should write chart files next to a results CSV."""
+    """The sweep --plot hook should write ONE combined HTML report next to the CSV."""
     pytest.importorskip("plotly.graph_objects")
     from t3co.cli.sweep import save_default_plots
 
@@ -108,12 +108,30 @@ def test_save_default_plots_cli_hook(tmp_path, results_df):
     results_df.to_csv(csv, index=False)
     saved = save_default_plots(csv, backend="plotly")
 
-    # breakdown + histogram (+ violin since the data has a fuel-type grouping)
-    assert len(saved) == 3
-    for path in saved:
-        assert path.exists()
-        assert path.suffix == ".html"
-        assert path.parent == tmp_path
+    # all charts (breakdown + histogram + violin) combined into a single HTML file
+    assert len(saved) == 1
+    report = saved[0]
+    assert report.exists()
+    assert report.suffix == ".html"
+    assert report.parent == tmp_path
+    # the report holds three plots in one page
+    assert report.read_text().count('class="plotly-graph-div"') == 3
+
+
+def test_write_html_report_combines_plots(tmp_path, results_df):
+    pytest.importorskip("plotly.graph_objects")
+    tc = T3COCharts(results_df=results_df, backend="plotly")
+    figs = [
+        tc.generate_tco_plots(x_group_col="vehicle_fuel_type"),
+        tc.generate_histogram(hist_col="discounted_tco_dol", n_bins=4),
+    ]
+    out = T3COCharts.write_html_report(figs, tmp_path / "report.html")
+    html = out.read_text()
+    # both plots present in one page
+    assert html.count('class="plotly-graph-div"') == 2
+    # self-contained: the library is embedded inline, not loaded from a CDN <script src>
+    assert 'src="https://cdn.plot.ly/plotly' not in html
+    assert len(html) > 1_000_000
 
 
 # ------------------------- matplotlib backend ------------------------- #


### PR DESCRIPTION
## Summary

Ports the 1.0.x `T3COCharts` charting into the 2.0 codebase as a proper visualization module, adapted to the 2.0 flattened results schema, with a **selectable rendering backend** (static matplotlib/seaborn **or** interactive Plotly HTML). Also adds a `--plot` flag to the sweep CLI so charts can be auto-generated after a run.

Closes #68
Closes #89

## What's included

- **`src/t3co/visualize/charts.py`** — `T3COCharts` with the original public API preserved (`generate_tco_plots`, `generate_violin_plot`, `generate_histogram`) plus a `backend="matplotlib"|"plotly"` switch.
  - Internally normalizes the 2.0 flattened/prefixed columns (`scenario_fuel_type`, `scenario_gvwr_kg`, `scenario_vocation`, `vehicle_veh_pt_type`, …) to the canonical grouping names used by the plots and `t3co_outputs_guide.csv`; derives `vehicle_weight_class` from GVWR. Also handles legacy bare-name CSVs.
  - Plotting libraries are **lazily, optionally imported** so base `t3co` stays importable without them. The cost-breakdown and histogram charts need only matplotlib (a transitive pymoo dependency); seaborn is required just for the violin, and Plotly just for the interactive HTML backend.
- **`pyproject.toml`** — new optional `viz` extra (`pip install t3co_go[viz]` → matplotlib, seaborn, plotly).
- **`src/t3co/cli/sweep.py`** — `--plot [plotly|matplotlib]` generates the default TCO charts after the results CSV is written and saves them next to it (wired into both the single-process and multiprocessing paths). Charting failures never abort a completed run.
- **`src/t3co/demos/visualization_demo.py`** — builds demo results and renders all three plots in both backends.
- **`tests/visualize/test_charts.py`** — 10 tests covering both backends, schema normalization, the `--plot` hook, and error paths.

## Verification

- `pytest tests/visualize/test_charts.py` → all green; `ruff` clean. CI Build passes on Python 3.9–3.13.
- Ran a real `--analysis-id 0` sweep with `--plot matplotlib` end-to-end (FASTSim energy): results CSV plus `*_tco_breakdown.png`, `*_tco_histogram.png`, `*_tco_violin.png` saved next to it.
- Validated column normalization against a live 184-column 2.0 results CSV.

## Notes
- A companion handoff for upgrading **T3CO-Go** (PyPI `t3co-go`) to consume T3CO 2.0 + this module (dependency bump, `visualization`→`visualize` import path, run-API migration, static/interactive toggle) was prepared separately.
